### PR TITLE
Update ClassyOrg_CampaignProgressWidget.php

### DIFF
--- a/widgets/ClassyOrg_CampaignProgressWidget.php
+++ b/widgets/ClassyOrg_CampaignProgressWidget.php
@@ -124,7 +124,7 @@ WIDGET_TEMPLATE;
 
         $goal = (empty($campaign['goal'])) ? 0 : $campaign['goal'];
         $totalRaised = (empty($campaign['overview']['total_gross_amount'])) ? 0 : ceil($campaign['overview']['total_gross_amount']);
-        $percentToGoal = ceil(($totalRaised / $goal) * 100);
+        $percentToGoal = ($goal > 0) ? ceil(($totalRaised / $goal) * 100) : 0;
 
         $html = sprintf(
             $widgetTemplate,


### PR DESCRIPTION
Fixing divide by zero error for fundraisers with a $0 target
