### PR TITLE
Fixes divison by zero PHP warning for campaigns that don't have any t…

### DIFF
--- a/widgets/ClassyOrg_CampaignOverviewWidget.php
+++ b/widgets/ClassyOrg_CampaignOverviewWidget.php
@@ -174,7 +174,7 @@ WIDGET_TEMPLATE;
         $grossTransactions = ceil($campaign['overview']['total_gross_amount']);
         $donorCount = (int)$campaign['overview']['donors_count'];
         $transactionCount = (int)$campaign['overview']['transactions_count'];
-        $averageTransaction = round($campaign['overview']['total_gross_amount'] / $transactionCount, 2);
+        $averageTransaction = ($transactionCount > 0) ? round($campaign['overview']['total_gross_amount'] / $transactionCount, 2) : 0;
 
         $html = sprintf(
             $widgetTemplate,


### PR DESCRIPTION
Addresses PHP 'Division by 0' warning (issue #2) by testing to see if transactions_count is more than 0. If it is 0, set $averageTransaction to 0.
