### PR TITLE
add_object_page has been deprecated since 4.5.0

### DIFF
--- a/ClassyOrg.php
+++ b/ClassyOrg.php
@@ -59,7 +59,7 @@ class ClassyOrg
      */
     public function settingsMenu()
     {
-        add_object_page(
+        add_menu_page(
             'Classy.org Settings',
             'Classy.org',
             'administrator',


### PR DESCRIPTION
Updated settingsMenu() function to use new add_menu_page syntax. See [here](https://developer.wordpress.org/reference/functions/add_object_page/)