### PR TITLE
removed activation hooks causing WP errors

### DIFF
--- a/ClassyOrg.php
+++ b/ClassyOrg.php
@@ -25,10 +25,6 @@ class ClassyOrg
 
     public function __construct()
     {
-        // Activation hooks
-        register_activation_hook(__FILE__, array('ClassyOrg', 'activate'));
-        register_deactivation_hook(__FILE__, array('ClassyOrg', 'deactivate'));
-
         // Admin menus
         add_action('admin_menu', array($this, 'settingsMenu'));
         add_action('admin_init', array($this, 'settingsRegister'));


### PR DESCRIPTION
Activating the plugin causes this WP error message to be shown, which is a poor user experience:

> The plugin generated 186 characters of unexpected output during activation. If you notice “headers already sent” messages, problems with syndication feeds or other issues, try deactivating or removing this plugin.

The underlying PHP error was:

`Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'ClassyOrg' does not have a method 'activate' in /app/public/wp-includes/class-wp-hook.php on line 298`

The activate and deactivate functions don't exist. At this time I don't see a need for them so I've removed them rather than commenting them out. This PR will eliminate the error message shown to users.