### PR TITLE
Add fundraiser and team logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Each of these accept parameters for `id` and `title`, as above with the short co
 
 Additional embeddable items coming soon:
 
-- Fundraiser and fundraising team images on leaderboards
+- ~~Fundraiser and fundraising team images on leaderboards~~
 - Organization overview of campaigns
 
 Other items:

--- a/css/classy_org.css
+++ b/css/classy_org.css
@@ -77,7 +77,17 @@
 {
     background-color: #303030;
     border-radius: 5px;
-    padding: 5px 10px;
+    width: 50px;
+    height: 50px;
+    display: table;
+    float: left;
+    overflow: hidden;
+}
+
+.classy-org-leaderboard_item-image i,img
+{
+    display: table-cell;
+    vertical-align: middle;
 }
 
 .classy-org-leaderboard_item-info-label

--- a/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
@@ -119,7 +119,7 @@ WIDGET_TEMPLATE;
 
     <div class="classy-org-leaderboard_item">
       <div class="classy-org-leaderboard_item-image">
-        <i class="fa fa-user fa-2x fa-inverse"></i>
+        %s
       </div>
       <div class="classy-org-leaderboard_item-info">
         <span class="classy-org-leaderboard_item-info-label">%s</span>
@@ -128,6 +128,8 @@ WIDGET_TEMPLATE;
     </div>
 
 ITEM_TEMPLATE;
+
+        $logoTemplate = '<img src="%s" />';
 
         if (!empty($params['title']))
         {
@@ -141,11 +143,15 @@ ITEM_TEMPLATE;
 
         foreach ($fundraisers as $fundraiser)
         {
+            $logoHtml = (empty($fundraiser['logo_url']))
+                ? '<i class="fa fa-user fa-2x fa-inverse fa-fw"></i>'
+                : sprintf($logoTemplate, $fundraiser['logo_url']);
             $name = (empty($fundraiser['alias']))
                 ? $fundraiser['supporter']['first_name'] . ' ' . $fundraiser['supporter']['last_name']
                 : $fundraiser['alias'];
             $itemsHtml .= sprintf(
                 $itemTemplate,
+                $logoHtml,
                 esc_html($name),
                 esc_html($fundraiser['total_raised'])
             );

--- a/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
@@ -151,7 +151,7 @@ ITEM_TEMPLATE;
                 : $fundraiser['alias'];
             $itemsHtml .= sprintf(
                 $itemTemplate,
-                $logoHtml,
+                wp_kses_post($logoHtml),
                 esc_html($name),
                 esc_html($fundraiser['total_raised'])
             );

--- a/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
@@ -148,7 +148,7 @@ ITEM_TEMPLATE;
             : sprintf($logoTemplate, $team['logo_url']);
             $itemsHtml .= sprintf(
                 $itemTemplate,
-                $logoHtml,
+                wp_kses_post($logoHtml),
                 esc_html($team['name']),
                 esc_html($team['total_raised'])
             );

--- a/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
@@ -119,7 +119,7 @@ WIDGET_TEMPLATE;
 
     <div class="classy-org-leaderboard_item">
       <div class="classy-org-leaderboard_item-image">
-        <i class="fa fa-group fa-2x fa-inverse"></i>
+        %s
       </div>
       <div class="classy-org-leaderboard_item-info">
         <span class="classy-org-leaderboard_item-info-label">%s</span>
@@ -128,6 +128,8 @@ WIDGET_TEMPLATE;
     </div>
 
 ITEM_TEMPLATE;
+
+        $logoTemplate = '<img src="%s" />';
 
         if (!empty($params['title']))
         {
@@ -141,8 +143,12 @@ ITEM_TEMPLATE;
 
         foreach ($teams as $team)
         {
+            $logoHtml = (empty($team['logo_url']))
+            ? '<i class="fa fa-group fa-2x fa-inverse fa-fw"></i>'
+            : sprintf($logoTemplate, $team['logo_url']);
             $itemsHtml .= sprintf(
                 $itemTemplate,
+                $logoHtml,
                 esc_html($team['name']),
                 esc_html($team['total_raised'])
             );


### PR DESCRIPTION
This shows fundraiser and team logos when available, falling back to FontAwesome icons when logos are not available.

CSS has been modified to ensure logos are consistently sized.

wp_kses_post() is used to sanitize HTML content generated.

Working on WP 4.8.2