### PR TITLE
Format currency: remove cents, add commas and rounding. Fixes #19

### DIFF
--- a/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
@@ -153,7 +153,7 @@ ITEM_TEMPLATE;
                 $itemTemplate,
                 wp_kses_post($logoHtml),
                 esc_html($name),
-                esc_html($fundraiser['total_raised'])
+                number_format(esc_html($fundraiser['total_raised']))
             );
         }
 

--- a/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraiserLeadersWidget.php
@@ -153,7 +153,7 @@ ITEM_TEMPLATE;
                 $itemTemplate,
                 wp_kses_post($logoHtml),
                 esc_html($name),
-                number_format(esc_html($fundraiser['total_raised']))
+                number_format($fundraiser['total_raised'])
             );
         }
 

--- a/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
@@ -150,7 +150,7 @@ ITEM_TEMPLATE;
                 $itemTemplate,
                 wp_kses_post($logoHtml),
                 esc_html($team['name']),
-                esc_html($team['total_raised'])
+                number_format(esc_html($team['total_raised']))
             );
         }
 

--- a/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
+++ b/widgets/ClassyOrg_CampaignFundraisingTeamLeadersWidget.php
@@ -150,7 +150,7 @@ ITEM_TEMPLATE;
                 $itemTemplate,
                 wp_kses_post($logoHtml),
                 esc_html($team['name']),
-                esc_html($team['total_raised'])
+                number_format($team['total_raised'])
             );
         }
 

--- a/widgets/ClassyOrg_CampaignOverviewWidget.php
+++ b/widgets/ClassyOrg_CampaignOverviewWidget.php
@@ -124,10 +124,10 @@ OVERVIEW_TABLE;
         $html = sprintf(
             $template,
             $title,
-            esc_html($transactionCount),
-            esc_html($grossTransactions),
-            esc_html($averageTransaction),
-            esc_html($donorCount)
+            number_format($transactionCount),
+            number_format($grossTransactions),
+            number_format($averageTransaction),
+            number_format($donorCount)
         );
 
         return $html;
@@ -179,10 +179,10 @@ WIDGET_TEMPLATE;
         $html = sprintf(
             $widgetTemplate,
             $title,
-            esc_html($grossTransactions),
-            esc_html($donorCount),
-            esc_html($transactionCount),
-            esc_html($averageTransaction)
+            number_format($grossTransactions),
+            number_format($donorCount),
+            number_format($transactionCount),
+            number_format($averageTransaction)
         );
 
         return $html;

--- a/widgets/ClassyOrg_CampaignProgressWidget.php
+++ b/widgets/ClassyOrg_CampaignProgressWidget.php
@@ -129,8 +129,8 @@ WIDGET_TEMPLATE;
         $html = sprintf(
             $widgetTemplate,
             $title,
-            esc_html($totalRaised),
-            esc_html($goal),
+            number_format($totalRaised),
+            number_format($goal),
             esc_html($percentToGoal)
         );
 


### PR DESCRIPTION
This fixes the issue where cents were not formatted correctly. It removes the decimal places entirely and adds commas and rounding courtesy of `number_format()`. See images below for how this change looks on my test system. 

![classy-org-wp no cents individual and team](https://user-images.githubusercontent.com/10197537/33457940-2bf651c6-d5f2-11e7-8fa0-9ab96f82053c.png)

![classy-org-wp no cents campaign](https://user-images.githubusercontent.com/10197537/33457939-29d13a82-d5f2-11e7-8b47-6367ec47465a.png)