### PR TITLE
Ensure transparent avatars are shown on white background

### DIFF
--- a/css/classy_org.css
+++ b/css/classy_org.css
@@ -75,7 +75,7 @@
 
 .classy-org-leaderboard_item-image
 {
-    background-color: #303030;
+    background-color: #fff;
     border-radius: 5px;
     width: 50px;
     height: 50px;
@@ -88,6 +88,11 @@
 {
     display: table-cell;
     vertical-align: middle;
+}
+
+.classy-org-leaderboard_item-image i
+{
+    background-color: #303030;
 }
 
 .classy-org-leaderboard_item-info-label


### PR DESCRIPTION
This changes the CSS to set a white background for user and team avatars, but keep the grey background for the font-awesome fallback icon when no avatar is present. This fixes an issue where partially transparent avatars looked bad on the grey background.

In attached image the "Penguin Plunge" logo has a transparent background and shows the white background instead of the orange test page background. The fontawesome icons still appear against a grey background.

![classy-org-white-img-backgrounds](https://user-images.githubusercontent.com/10197537/33458204-4aa1e92c-d5f3-11e7-95db-f5e86c8f86e4.png)
